### PR TITLE
Simplify exporter service state management

### DIFF
--- a/internal/exporter/lister.go
+++ b/internal/exporter/lister.go
@@ -13,11 +13,12 @@ import (
 	"strings"
 )
 
-func NewHTTPDumpLister(baseURL string, client *http.Client) DumpLister {
+func NewHTTPDumpLister(baseURL string, client *http.Client) func(ctx context.Context) ([]DumpFile, error) {
 	// Trim the trailing slash so url.JoinPath doesn't introduce double separators
 	// when we later append file names. A bare root URL ("/") remains untouched.
 	base := strings.TrimSuffix(baseURL, "/")
-	return &httpLister{base: base, client: client}
+	l := &httpLister{base: base, client: client}
+	return l.List
 }
 
 type httpLister struct {


### PR DESCRIPTION
## Summary
- simplify exporter service state handling so List returns the full export state and background jobs rely on a single running flag
- reduce exporter metrics to progress plus a running gauge and replace the DumpLister interface with a simple function
- update exporter tests to poll metrics for completion instead of using the removed Wait helper

## Testing
- go test ./... *(fails: requires libzim via pkg-config)*

------
https://chatgpt.com/codex/tasks/task_e_68d55416f5ac83238f8586a91a14a7be